### PR TITLE
NATMap: Fix Ctrl-C not working on Windows

### DIFF
--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -18,6 +18,7 @@
 
 #include "hev-conf.h"
 #include "hev-misc.h"
+#include "hev-winc.h"
 #include "hev-xnsk.h"
 
 #include "hev-main.h"
@@ -31,6 +32,14 @@ main (int argc, char *argv[])
     };
     struct timeval tv;
     int res;
+
+#if defined(__MSYS__)
+    res = hev_winc_setup_ctrlc ();
+    if (res < 0) {
+        LOG (E);
+        return -3;
+    }
+#endif
 
     res = hev_conf_init (argc, argv);
     if (res < 0) {

--- a/src/hev-winc.c
+++ b/src/hev-winc.c
@@ -1,0 +1,28 @@
+/*
+ ============================================================================
+ Name        : hev-winc.c
+ Author      : hev <r@hev.cc>
+ Copyright   : Copyright (c) 2025 xyz
+ Description : Functions for Windows console
+ ============================================================================
+ */
+
+#if defined(__MSYS__)
+
+#include <windows.h>
+
+static BOOL WINAPI
+ctrlHandler (DWORD signal)
+{
+    if (signal == CTRL_C_EVENT)
+        exit (STATUS_CONTROL_C_EXIT);
+    return TRUE;
+}
+
+int
+hev_winc_setup_ctrlc (void)
+{
+    return SetConsoleCtrlHandler (ctrlHandler, TRUE) ? 0 : -1;
+}
+
+#endif /* defined(__MSYS__) */

--- a/src/hev-winc.h
+++ b/src/hev-winc.h
@@ -1,0 +1,20 @@
+/*
+ ============================================================================
+ Name        : hev-winc.h
+ Author      : hev <r@hev.cc>
+ Copyright   : Copyright (c) 2025 xyz
+ Description : Functions for Windows console
+ ============================================================================
+ */
+
+#ifndef __HEV_WINC_H__
+#define __HEV_WINC_H__
+
+/**
+ * hev_winc_setup_ctrlc:
+ *
+ * Setup Ctrl-C handler for Windows console.
+ */
+int hev_winc_setup_ctrlc (void);
+
+#endif /* __HEV_WINC_H__ */


### PR DESCRIPTION
Windows 平台下，Ctrl-C 响应缓慢或者无反应。
此 PR 解决该问题。在按下 Ctrl-C 之后，NATMap 便可很快退出。