### PR TITLE
HevExec: Fix fork and exec on Windows

### DIFF
--- a/src/hev-exec.h
+++ b/src/hev-exec.h
@@ -2,13 +2,26 @@
  ============================================================================
  Name        : hev-exec.h
  Author      : hev <r@hev.cc>
- Copyright   : Copyright (c) 2022 xyz
+ Copyright   : Copyright (c) 2022 - 2025 xyz
  Description : Exec
  ============================================================================
  */
 
 #ifndef __HEV_EXEC_H__
 #define __HEV_EXEC_H__
+
+#ifdef __MSYS__
+#define HEV_EXEC_STACK_SIZE (16384)
+#else
+#define HEV_EXEC_STACK_SIZE (1)
+#endif
+
+/**
+ * hev_exec_init:
+ *
+ * Initialize exec.
+ */
+void hev_exec_init (void *stack);
 
 /**
  * hev_exec_run:

--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -2,7 +2,7 @@
  ============================================================================
  Name        : hev-main.c
  Author      : hev <r@hev.cc>
- Copyright   : Copyright (c) 2022 xyz
+ Copyright   : Copyright (c) 2022 - 2025 xyz
  Description : Main
  ============================================================================
  */
@@ -17,6 +17,7 @@
 #include <hev-task-system.h>
 
 #include "hev-conf.h"
+#include "hev-exec.h"
 #include "hev-misc.h"
 #include "hev-winc.h"
 #include "hev-xnsk.h"
@@ -26,6 +27,7 @@
 int
 main (int argc, char *argv[])
 {
+    char stack[HEV_EXEC_STACK_SIZE];
     struct rlimit limit = {
         .rlim_cur = 65536,
         .rlim_max = 65536,
@@ -60,6 +62,7 @@ main (int argc, char *argv[])
 
     signal (SIGPIPE, SIG_IGN);
     setrlimit (RLIMIT_NOFILE, &limit);
+    hev_exec_init (&stack[HEV_EXEC_STACK_SIZE]);
 
     res = hev_task_system_init ();
     if (res < 0) {


### PR DESCRIPTION
msys `fork()`过程中，父子进程内存clone的顺序不能适应协程任务换栈的场景，导致过程中栈空间短暂不可访问。

修复思路是在`main()`函数中保留一块足够大小的栈空间，在exec时使用task call机制换回到之前保留的原生线程栈上执行。