### PR TITLE
CI: Update macOS builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -161,6 +161,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  macos:
+    name: macOS
+    runs-on: macos-14
+    strategy:
+      matrix:
+        include:
+          - name: arm64
+            flags: -arch arm64 -mmacosx-version-min=11.0
+          - name: x86_64
+            flags: -arch x86_64 -mmacosx-version-min=10.6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+      - name: Build ${{ matrix.name }}
+        run: |
+          make CC=clang CFLAGS="${{ matrix.flags }}" LFLAGS="${{ matrix.flags }}" -j $(sysctl -n hw.logicalcpu)
+          cp bin/natmap natmap-darwin-${{ matrix.name }}
+      - name: Upload ${{ matrix.name }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: natmap-darwin-${{ matrix.name }}
+          path: natmap-darwin-${{ matrix.name }}
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: Release
     runs-on: ubuntu-22.04
@@ -168,6 +196,7 @@ jobs:
       - source
       - linux
       - windows
+      - macos
     if: github.event_name == 'release'
     steps:
       - name: Checkout
@@ -187,20 +216,6 @@ jobs:
           for i in release/natmap-*; do
             gh release upload ${{ github.event.release.tag_name }} $i
           done
-
-  macos:
-    name: macOS
-    runs-on: macos-14
-    if: github.event_name != 'release'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          submodules: true
-      - name: Build
-        run: |
-          make
 
   android:
     name: Android


### PR DESCRIPTION
更新了 CI：
- macOS x86_64 版本可在 >= 10.6 (Snow Leopard, 2009) 环境运行；
- macOS arm64 版本可在 >= 11.0 (Big Sur, 2020) 环境运行，Big Sur 是第一个 arm64 的 macOS。

由于我们没有 Apple 的签名证书，所以用户运行前需要手动去除 `com.apple.quarantine` 标记，参考以下命令（可以考虑添加到文档）：

```
chmod +x ./natmap-darwin-arm64
xattr -d com.apple.quarantine ./natmap-darwin-arm64
```

---

此外，macOS 默认编译器为 Apple Clang，`gcc` 只是一个别名：

```
~% gcc -v
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.6.0
Thread model: posix
InstalledDir: /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

为了明确，此处指定 `CC=clang`。

---

编译过程中会产生以下 warning，这是正常的。宏定义的原因导致这些文件实际是空的，确实没有 symbol。
```
/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: bin/libhev-task-system.a(hev-task-io-reactor-epoll.o) has no symbols
/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: bin/libhev-task-system.a(hev-task-io-reactor-wsa.o) has no symbols
/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: bin/libhev-task-system.a(hev-task-stack-heap.o) has no symbols
/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: bin/libhev-task-system.a(hev-debugger.o) has no symbols
```