### PR TITLE
NATMap: allow -b 0 to retain port if still available

### DIFF
--- a/src/hev-conf.c
+++ b/src/hev-conf.c
@@ -165,7 +165,9 @@ hev_conf_init (int argc, char *argv[])
     }
 
     if (!bport[0]) {
-        bport[0] = 0;
+        bport[0] = 1;
+        bport[1] = 65535;
+        brand = 1;
     }
     if (!bport[1]) {
         bport[1] = bport[0];


### PR DESCRIPTION
-b 0的时候使用bind()函数来随机分配一个可用端口
绕过了hev_conf_bport (int next)函数来切换端口

当-b 0时通过hev_conf.c手动设置bport[0]=1,bport[1]=65535,brand =1;然后通过hev_conf_bport函数随机生成一个1~65535内的一个端口这样受到next变量影响不会在下次绑定的时候切换端口
虽然无法做到bind函数选择一个没有被占用的端口，但是当随机分配到一个被占用的端口时会自动切换端口，保留了当端口可用时不切换端口的能力

代码水平有限，不知可有更好的方案？